### PR TITLE
fix: correct typo 'recieve' to 'receive'

### DIFF
--- a/natix/base/miner.py
+++ b/natix/base/miner.py
@@ -244,7 +244,7 @@ class BaseMinerNeuron(BaseNeuron):
         Returns:
             float: A priority score derived from the stake of the calling entity.
 
-        Miners may recieve messages from multiple entities at once. This function determines which request should be
+        Miners may receive messages from multiple entities at once. This function determines which request should be
         processed first. Higher values indicate that the request should be processed first. Lower values indicate
         that the request should be processed later.
 


### PR DESCRIPTION
Fixed typo in miner base class.