### PR TITLE
Fix validator config path in documentation

### DIFF
--- a/docs/validating.md
+++ b/docs/validating.md
@@ -79,7 +79,7 @@ HUGGING_FACE_TOKEN=your_hugging_face_token_here
 
 To run the validator:
 ```bash
-pm2 start ecosystem.validator.config.js
+pm2 start scripts/ecosystem.validator.config.js
 ```
 
 Optional flags:


### PR DESCRIPTION
Updated the path for the validator configuration file in the documentation.